### PR TITLE
Normalize conditionGroups shape, merge condition values, and refactor validation to fix missing first condition & lints

### DIFF
--- a/src/businessRulesWithGroup/BusinessRuleView/index.tsx
+++ b/src/businessRulesWithGroup/BusinessRuleView/index.tsx
@@ -8,61 +8,61 @@ import { IBusinessRuleView } from "../types/BusinessRuleView";
 import { strategyFactoryHandlerManager } from "./helper";
 import { BusinessRuleViewUI } from "./interface";
 
+const getFirstGroup = (cg: any) => (Array.isArray(cg) ? cg[0] : cg ?? null);
+const getConditionsFromDecision = (decision: any) =>
+  getFirstGroup(decision?.conditionGroups)?.conditionsThatEstablishesTheDecision ?? [];
+
 const BusinessRuleViewWithGroup = (props: IBusinessRuleView) => {
   const { decision, loading = false, textValues } = props;
 
   const hasEffectiveFrom = Boolean(decision?.effectiveFrom);
   const hasValidUntil = Boolean(decision?.validUntil);
-
   const decisionDateElement =
     hasEffectiveFrom && hasValidUntil
       ? {
+        element: {
+          labelName: textValues?.terms,
+          value: String(decision!.effectiveFrom),
+          howToSetTheDecision: ValueHowToSetUp.RANGE,
+          decisionDataType: ValueDataType.DATE,
+        },
+        valueData: strategyFactoryHandlerManager({
+          labelName: textValues?.terms,
+          value: {
+            from: String(decision!.effectiveFrom),
+            to: String(decision!.validUntil),
+          },
+          howToSetTheDecision: ValueHowToSetUp.RANGE,
+          decisionDataType: ValueDataType.DATE,
+        }),
+      }
+      : hasEffectiveFrom && !hasValidUntil
+        ? {
           element: {
             labelName: textValues?.terms,
             value: String(decision!.effectiveFrom),
-            howToSetTheDecision: ValueHowToSetUp.RANGE,
+            howToSetTheDecision: ValueHowToSetUp.EQUAL,
             decisionDataType: ValueDataType.DATE,
           },
           valueData: strategyFactoryHandlerManager({
             labelName: textValues?.terms,
-            value: {
-              from: String(decision!.effectiveFrom),
-              to: String(decision!.validUntil),
-            },
-            howToSetTheDecision: ValueHowToSetUp.RANGE,
+            value: String(decision!.effectiveFrom),
+            howToSetTheDecision: ValueHowToSetUp.EQUAL,
             decisionDataType: ValueDataType.DATE,
           }),
         }
-      : hasEffectiveFrom && !hasValidUntil
-        ? {
-            element: {
-              labelName: textValues?.terms,
-              value: String(decision!.effectiveFrom),
-              howToSetTheDecision: ValueHowToSetUp.EQUAL,
-              decisionDataType: ValueDataType.DATE,
-            },
-            valueData: strategyFactoryHandlerManager({
-              labelName: textValues?.terms,
-              value: String(decision!.effectiveFrom),
-              howToSetTheDecision: ValueHowToSetUp.EQUAL,
-              decisionDataType: ValueDataType.DATE,
-            }),
-          }
         : null;
 
   const decisionMapper: IRuleDecision | null = decision
     ? {
-        labelName: decision.labelName || "",
-        decisionDataType: decision.decisionDataType || "alphabetical",
-        value: strategyFactoryHandlerManager(decision),
-        howToSetTheDecision: decision.howToSetTheDecision || "EqualTo",
-      }
+      labelName: decision.labelName || "",
+      decisionDataType: decision.decisionDataType || "alphabetical",
+      value: strategyFactoryHandlerManager(decision),
+      howToSetTheDecision: decision.howToSetTheDecision || "EqualTo",
+    }
     : null;
 
-  const visibleConditions =
-    decision?.conditionGroups[0]?.conditionsThatEstablishesTheDecision?.filter(
-      (condition: any) => !condition.hidden,
-    ) || [];
+const visibleConditions = getConditionsFromDecision(decision).filter((c: any) => !c?.hidden);
   const skeleton = Array.from({ length: 5 });
   const loadingValidation = Boolean(
     !loading && decision && textValues && decisionMapper,

--- a/src/businessRulesWithGroup/Cards/BusinessRuleCard/index.tsx
+++ b/src/businessRulesWithGroup/Cards/BusinessRuleCard/index.tsx
@@ -3,7 +3,7 @@ import { Divider, Stack, Icon } from "@inubekit/inubekit";
 import { StyledCard } from "./styles";
 import { IBusinessRuleCard } from "../../../businessRules/types/Cards/BusinessRuleCard/IBusinessRuleCard";
 
-const BusinessRuleCard = (props: IBusinessRuleCard) => {
+const BusinessRuleCardWithGroup = (props: IBusinessRuleCard) => {
   const { children, controls = true, handleDelete, id } = props;
   return (
     <StyledCard>
@@ -30,4 +30,4 @@ const BusinessRuleCard = (props: IBusinessRuleCard) => {
   );
 };
 
-export { BusinessRuleCard };
+export { BusinessRuleCardWithGroup };

--- a/src/businessRulesWithGroup/Cards/BusinessRuleCard/stories/BusinessRuleCard.stories.tsx
+++ b/src/businessRulesWithGroup/Cards/BusinessRuleCard/stories/BusinessRuleCard.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "@isettingkit/input";
 import { IBusinessRuleCard } from "../../../../businessRules/types/Cards/BusinessRuleCard/IBusinessRuleCard";
 import { EValueHowToSetUp } from "../../../../businessRules/enums/EValueHowToSetUp";
-import { BusinessRuleViewWithGroup } from "src/businessRulesWithGroup/BusinessRuleView";
+import { BusinessRuleViewWithGroup } from "../../../../businessRulesWithGroup/BusinessRuleView";
 import { BusinessRuleCardWithGroup } from "..";
 
 const meta: Meta<typeof BusinessRuleCardWithGroup> = {

--- a/src/businessRulesWithGroup/Cards/BusinessRuleCard/stories/BusinessRuleCard.stories.tsx
+++ b/src/businessRulesWithGroup/Cards/BusinessRuleCard/stories/BusinessRuleCard.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import { parameters, props } from "./props";
-import { BusinessRuleCard } from "..";
+
 
 import {
   IRuleDecision,
@@ -11,18 +11,19 @@ import {
 import { IBusinessRuleCard } from "../../../../businessRules/types/Cards/BusinessRuleCard/IBusinessRuleCard";
 import { EValueHowToSetUp } from "../../../../businessRules/enums/EValueHowToSetUp";
 import { BusinessRuleViewWithGroup } from "src/businessRulesWithGroup/BusinessRuleView";
+import { BusinessRuleCardWithGroup } from "..";
 
-const meta: Meta<typeof BusinessRuleCard> = {
+const meta: Meta<typeof BusinessRuleCardWithGroup> = {
   title: "components/BusinessRules/BusinessRuleCardWithGroup",
-  component: BusinessRuleCard,
+  component: BusinessRuleCardWithGroup,
   parameters,
   argTypes: props,
 };
 
-type Story = StoryObj<typeof BusinessRuleCard>;
+type Story = StoryObj<typeof BusinessRuleCardWithGroup>;
 
 export const Default: Story = (args: IBusinessRuleCard) => (
-  <BusinessRuleCard {...args} />
+  <BusinessRuleCardWithGroup {...args} />
 );
 Default.args = {
   children: (
@@ -108,7 +109,7 @@ const getData = (): IRuleDecision => {
 };
 
 const Container: Story = (args: IBusinessRuleCard) => (
-  <BusinessRuleCard {...args} />
+  <BusinessRuleCardWithGroup {...args} />
 );
 Container.args = {
   children: (

--- a/src/businessRulesWithGroup/Form/index.tsx
+++ b/src/businessRulesWithGroup/Form/index.tsx
@@ -53,8 +53,16 @@ const RulesFormWithGroup = (props: IRulesForm) => {
           false,
           false,
         );
+        const allConditionsTouched = Object.keys(formik.touched)
+          .filter(key => key.startsWith('conditionsThatEstablishesTheDecision.'))
+          .some(key => formik.touched[key] === true);
+          
+        if (!allConditionsTouched) {
+          handleToggleNoneChange(true);
+        }
       } else {
         const defaultValue = isMulti ? [] : "";
+        handleToggleNoneChange(false);
         formik.setFieldValue(
           `conditionsThatEstablishesTheDecision.${conditionName}`,
           defaultValue,

--- a/src/businessRulesWithGroup/Form/index.tsx
+++ b/src/businessRulesWithGroup/Form/index.tsx
@@ -69,8 +69,7 @@ const RulesFormWithGroup = (props: IRulesForm) => {
         );
       }
     };
-  console.log("decision", decision, formik);
-  console.log("visibleConditions", visibleConditions);
+  
   return (
     <RulesFormUI
       formik={formik}

--- a/src/businessRulesWithGroup/Form/index.tsx
+++ b/src/businessRulesWithGroup/Form/index.tsx
@@ -21,7 +21,7 @@ const RulesFormWithGroup = (props: IRulesForm) => {
   };
 
   const visibleConditions =
-    decision.conditionGroups?.conditionsThatEstablishesTheDecision?.filter(
+    decision.conditionGroups[0]?.conditionsThatEstablishesTheDecision?.filter(
       (condition: { hidden: any }) => !condition.hidden,
     ) || [];
 

--- a/src/businessRulesWithGroup/Form/interface.tsx
+++ b/src/businessRulesWithGroup/Form/interface.tsx
@@ -70,8 +70,7 @@ const RulesFormUI = (props: IRulesFormUI) => {
                     labelToggle={condition.labelName}
                     checked={
                       !formik.values.toggleNone &&
-                      formik.values.conditionGroups[0]
-                        .conditionsThatEstablishesTheDecision[
+                      formik.values.conditionsThatEstablishesTheDecision?.[
                         condition.conditionName
                       ] !== undefined
                     }

--- a/src/businessRulesWithGroup/helper/strategies/decisionCard.tsx
+++ b/src/businessRulesWithGroup/helper/strategies/decisionCard.tsx
@@ -1,8 +1,8 @@
 import { Text, Stack } from "@inubekit/inubekit";
 import { StyledFadeInStack } from "../../../businessRules/styles";
-import { BusinessRuleCard } from "../../../businessRules/Cards/BusinessRuleCard";
 import { IRenderCard } from "../../../businessRules/types/helper";
 import { BusinessRuleViewWithGroup } from "../../../businessRulesWithGroup/BusinessRuleView";
+import { BusinessRuleCardWithGroup } from "../../../businessRulesWithGroup/Cards/BusinessRuleCard";
 
 const renderDecisionCard = (props: IRenderCard) => {
   const { decision, controls, handleOpenModal, handleDelete, textValues } =
@@ -15,7 +15,7 @@ const renderDecisionCard = (props: IRenderCard) => {
         <Text type="title" size="medium" appearance="gray" weight="bold">
           {decision.decisionId}
         </Text>
-        <BusinessRuleCard
+        <BusinessRuleCardWithGroup
           id={decision.decisionId!}
           handleDelete={() =>
             handleDelete ? handleDelete(decision.decisionId!) : null
@@ -29,7 +29,7 @@ const renderDecisionCard = (props: IRenderCard) => {
             decision={decision}
             textValues={textValues}
           />
-        </BusinessRuleCard>
+        </BusinessRuleCardWithGroup>
       </Stack>
     </StyledFadeInStack>
   );

--- a/src/businessRulesWithGroup/helper/utils/formatDecisionForBackend/index.ts
+++ b/src/businessRulesWithGroup/helper/utils/formatDecisionForBackend/index.ts
@@ -21,7 +21,6 @@ const formatDecisionForBackend = (props: {
   };
 
   const formattedConditions: any =
-  console.log('formattedConditions: ',decision);
     decision.conditionsThatEstablishesTheDecision
       ?.map((incomingCondition, index) => {
         const val = incomingCondition?.value;
@@ -37,11 +36,10 @@ const formatDecisionForBackend = (props: {
         return {
           ...template.conditionsThatEstablishesTheDecision?.[index],
           ...incomingCondition,
-          value: formatValue(val),
+          value: formatValue(val)
         };
       })
       .filter(Boolean) ?? [];
-
   return {
     ...template,
     ...decision,

--- a/src/businessRulesWithGroup/helper/utils/formatDecisionForBackend/index.ts
+++ b/src/businessRulesWithGroup/helper/utils/formatDecisionForBackend/index.ts
@@ -21,6 +21,7 @@ const formatDecisionForBackend = (props: {
   };
 
   const formattedConditions: any =
+  console.log('formattedConditions: ',decision);
     decision.conditionsThatEstablishesTheDecision
       ?.map((incomingCondition, index) => {
         const val = incomingCondition?.value;

--- a/src/businessRulesWithGroup/helper/utils/normalizeDecisionGroups/index.ts
+++ b/src/businessRulesWithGroup/helper/utils/normalizeDecisionGroups/index.ts
@@ -1,0 +1,28 @@
+import { IRuleDecision } from "@isettingkit/input";
+
+const normalizeDecisionGroups = (
+  decision: IRuleDecision,
+  defaultGroupId = "group-primary",
+): IRuleDecision => {
+  const legacy = decision.conditionsThatEstablishesTheDecision ?? [];
+
+  const groupId =
+    decision.conditionGroups?.ConditionGroupId ?? defaultGroupId;
+
+  const grouped = decision.conditionGroups?.conditionsThatEstablishesTheDecision ?? [];
+
+  const merged =
+    (grouped?.length ? grouped : legacy) ?? [];
+
+  const { conditionsThatEstablishesTheDecision, ...rest } = decision as any;
+  console.log('normalizeDecisions', decision.conditionGroups )
+  return {
+    ...rest,
+    conditionGroups: {
+      ConditionGroupId: groupId,
+      conditionsThatEstablishesTheDecision: merged,
+    },
+  };
+};
+
+export { normalizeDecisionGroups };

--- a/src/businessRulesWithGroup/stories/businessRulesWithGroup.addCard.stories.tsx
+++ b/src/businessRulesWithGroup/stories/businessRulesWithGroup.addCard.stories.tsx
@@ -37,7 +37,7 @@ const sampleDecisions: any[] = [
             descriptionUse: "Line of credit.",
             conditionDataType: ValueDataType.ALPHABETICAL,
             howToSetTheCondition: EValueHowToSetUp.EQUAL,
-            value: "credito 1",
+            value: "Linea de credito numero 1",
             i18n: {
               es: "Línea de crédito",
             },
@@ -58,77 +58,78 @@ const decisionTemplate: any = {
   value: "",
   effectiveFrom: "",
   validUntil: "",
-  conditionGroups: [  {
-    ConditionGroupId: "group-primary",
-    conditionsThatEstablishesTheDecision: [
-      {
-        labelName: "Line of credit",
-        conditionName: "LineOfCredit",
-        descriptionUse: "Line of credit.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Línea de crédito",
+  conditionGroups: [
+    {
+      ConditionGroupId: "group-primary",
+      conditionsThatEstablishesTheDecision: [
+        {
+          labelName: "Line of credit",
+          conditionName: "LineOfCredit",
+          descriptionUse: "Line of credit.",
+          conditionDataType: ValueDataType.ALPHABETICAL,
+          howToSetTheCondition: EValueHowToSetUp.EQUAL,
+          value: "",
+          i18n: {
+            es: "Línea de crédito",
+          },
         },
-      },
-      {
-        labelName: "Money Destination",
-        conditionName: "MoneyDestination",
-        descriptionUse: "Money Destination.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Destino de dinero",
+        {
+          labelName: "Money Destination",
+          conditionName: "MoneyDestination",
+          descriptionUse: "Money Destination.",
+          conditionDataType: ValueDataType.ALPHABETICAL,
+          howToSetTheCondition: EValueHowToSetUp.EQUAL,
+          value: "",
+          i18n: {
+            es: "Destino de dinero",
+          },
         },
-      },
-      {
-        labelName: "Loan amount",
-        conditionName: "LoanAmount",
-        descriptionUse: "Loan amount",
-        conditionDataType: ValueDataType.MONETARY,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Monto del préstamo",
+        {
+          labelName: "Loan amount",
+          conditionName: "LoanAmount",
+          descriptionUse: "Loan amount",
+          conditionDataType: ValueDataType.MONETARY,
+          howToSetTheCondition: EValueHowToSetUp.RANGE,
+          value: "",
+          i18n: {
+            es: "Monto del préstamo",
+          },
         },
-      },
-      {
-        labelName: "Primary Income Type.",
-        conditionName: "PrimaryIncomeType",
-        descriptionUse: "Primary income type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Tipo de fuente de ingreso primaria",
+        {
+          labelName: "Primary Income Type.",
+          conditionName: "PrimaryIncomeType",
+          descriptionUse: "Primary income type.",
+          conditionDataType: ValueDataType.ALPHABETICAL,
+          howToSetTheCondition: EValueHowToSetUp.RANGE,
+          value: "",
+          i18n: {
+            es: "Tipo de fuente de ingreso primaria",
+          },
         },
-      },
-      {
-        labelName: "Client Type",
-        conditionName: "ClientType",
-        descriptionUse: "Client Type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Tipo de cliente",
+        {
+          labelName: "Client Type",
+          conditionName: "ClientType",
+          descriptionUse: "Client Type.",
+          conditionDataType: ValueDataType.ALPHABETICAL,
+          howToSetTheCondition: EValueHowToSetUp.EQUAL,
+          value: "",
+          i18n: {
+            es: "Tipo de cliente",
+          },
         },
-      },
-      {
-        labelName: "Loan Term",
-        conditionName: "LoanTerm",
-        descriptionUse: "Loan Term.",
-        conditionDataType: ValueDataType.NUMBER,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Plazo del préstamo",
+        {
+          labelName: "Loan Term",
+          conditionName: "LoanTerm",
+          descriptionUse: "Loan Term.",
+          conditionDataType: ValueDataType.NUMBER,
+          howToSetTheCondition: EValueHowToSetUp.RANGE,
+          value: "",
+          i18n: {
+            es: "Plazo del préstamo",
+          },
         },
-      },
-    ],
-  },]
+      ],
+    },]
   ,
 
   i18n: {

--- a/src/businessRulesWithGroup/stories/businessRulesWithGroup.addCard.stories.tsx
+++ b/src/businessRulesWithGroup/stories/businessRulesWithGroup.addCard.stories.tsx
@@ -58,7 +58,7 @@ const decisionTemplate: any = {
   value: "",
   effectiveFrom: "",
   validUntil: "",
-  conditionGroups: {
+  conditionGroups: [  {
     ConditionGroupId: "group-primary",
     conditionsThatEstablishesTheDecision: [
       {
@@ -128,143 +128,9 @@ const decisionTemplate: any = {
         },
       },
     ],
-    "aditional-group-1": [
-      {
-        labelName: "Line of credit",
-        conditionName: "LineOfCredit1",
-        descriptionUse: "Line of credit.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Línea de crédito",
-        },
-      },
-      {
-        labelName: "Money Destination",
-        conditionName: "MoneyDestination1",
-        descriptionUse: "Money Destination.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Destino de dinero",
-        },
-      },
-      {
-        labelName: "Loan amount",
-        conditionName: "LoanAmount1",
-        descriptionUse: "Loan amount",
-        conditionDataType: ValueDataType.CURRENCY,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Monto del préstamo",
-        },
-      },
-      {
-        labelName: "Primary income type.",
-        conditionName: "PrimaryIncomeType1",
-        descriptionUse: "Primary income type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Tipo de fuente de ingreso primaria.",
-        },
-      },
-      {
-        labelName: "Client Type",
-        conditionName: "ClientType1",
-        descriptionUse: "Client Type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Tipo de cliente",
-        },
-      },
-      {
-        labelName: "Loan Term",
-        conditionName: "LoanTerm1",
-        descriptionUse: "Loan Term.",
-        conditionDataType: ValueDataType.NUMBER,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Plazo del préstamo",
-        },
-      },
-    ],
-    "aditional-group-2": [
-      {
-        labelName: "Line of credit",
-        conditionName: "LineOfCredit2",
-        descriptionUse: "Line of credit.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Línea de crédito",
-        },
-      },
-      {
-        labelName: "Money Destination",
-        conditionName: "MoneyDestination2",
-        descriptionUse: "Money Destination.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Destino de dinero",
-        },
-      },
-      {
-        labelName: "Loan amount",
-        conditionName: "LoanAmount2",
-        descriptionUse: "Loan amount",
-        conditionDataType: ValueDataType.MONETARY,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Monto del préstamo",
-        },
-      },
-      {
-        labelName: "Primary income type.",
-        conditionName: "PrimaryIncomeType2",
-        descriptionUse: "Primary income type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Tipo de fuente de ingreso primaria.",
-        },
-      },
-      {
-        labelName: "Client Type",
-        conditionName: "ClientType2",
-        descriptionUse: "Client Type.",
-        conditionDataType: ValueDataType.ALPHABETICAL,
-        howToSetTheCondition: EValueHowToSetUp.EQUAL,
-        value: "",
-        i18n: {
-          es: "Tipo de cliente",
-        },
-      },
-      {
-        labelName: "Loan Term",
-        conditionName: "LoanTerm2",
-        descriptionUse: "Loan Term.",
-        conditionDataType: ValueDataType.NUMBER,
-        howToSetTheCondition: EValueHowToSetUp.RANGE,
-        value: "",
-        i18n: {
-          es: "Plazo del préstamo",
-        },
-      },
-    ],
-  },
+  },]
+  ,
+
   i18n: {
     en: "Interest rate type",
     es: "Tipo de tasa de interés",

--- a/src/businessRulesWithGroup/stories/businessRulesWithGroup.controller.tsx
+++ b/src/businessRulesWithGroup/stories/businessRulesWithGroup.controller.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from "react";
-import { IRuleDecision } from "@isettingkit/input";
+import { IRuleDecision, IValue } from "@isettingkit/input";
 import { sortDisplayDataSwitchPlaces } from "../helper/utils/sortDisplayDataSwitchPlaces";
 import { sortDisplayDataSampleSwitchPlaces } from "../helper/utils/sortDisplayDataSampleSwitchPlaces";
 import { IRulesFormTextValues } from "../types/Forms/IRulesFormTextValues";
@@ -11,9 +12,9 @@ interface IBusinessRulesController {
   controls?: boolean;
   customTitleContentAddCard?: string;
   customMessageEmptyDecisions?: string;
-  initialDecisions: IRuleDecision[];
+  initialDecisions: IRuleDecision[] | any;
   textValues: IRulesFormTextValues;
-  decisionTemplate: IRuleDecision;
+  decisionTemplate: IRuleDecision | any;
   loading?: boolean;
   terms?: boolean;
 }
@@ -32,8 +33,8 @@ const BusinessRulesController = ({
     useState<IRuleDecision | null>(null);
    
   const [decisions, setDecisions] = useState<IRuleDecision[]>(
-    initialDecisions.map((decision) => (
-       console.log('decision.conditionsThatEstablishesTheDecision', decision.conditionGroups),{
+    initialDecisions.map((decision: { value: string | number | IValue | string[] | undefined; conditionGroups: { conditionsThatEstablishesTheDecision: any[]; }[]; }) => (
+      {
       ...decision,
       value: parseRangeFromString(decision.value),
       conditionsThatEstablishesTheDecision:
@@ -54,7 +55,7 @@ const BusinessRulesController = ({
     setSelectedDecision(null);
   };
 
-  const handleSubmitForm = (dataDecision: IRuleDecision) => {
+  const handleSubmitForm = (dataDecision: IRuleDecision | any) => {
     const isEditing = selectedDecision !== null;
 
     const newDecision = isEditing
@@ -68,10 +69,12 @@ const BusinessRulesController = ({
           decisionId: `Decisión ${decisions.length + 1}`,
           conditions:
             decisionTemplate.conditionGroups.conditionsThatEstablishesTheDecision?.map(
-              (conditionTemplate, index) => ({
+              (conditionTemplate: { value: any; }, index: string | number) => (console.log('onSubmit: '),{
                 ...conditionTemplate,
+                conditionDataType: "alphabetical",
+                howToSetTheCondition: "EqualTo",
                 value:
-                  dataDecision.conditionGroups[0].conditionsThatEstablishesTheDecision?.[index]
+                  dataDecision.conditionGroups.conditionsThatEstablishesTheDecision?.[index]
                     ?.value ?? conditionTemplate.value,
               }),
             ) ?? [],

--- a/src/businessRulesWithGroup/stories/businessRulesWithGroup.controller.tsx
+++ b/src/businessRulesWithGroup/stories/businessRulesWithGroup.controller.tsx
@@ -30,12 +30,14 @@ const BusinessRulesController = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDecision, setSelectedDecision] =
     useState<IRuleDecision | null>(null);
+   
   const [decisions, setDecisions] = useState<IRuleDecision[]>(
-    initialDecisions.map((decision) => ({
+    initialDecisions.map((decision) => (
+       console.log('decision.conditionsThatEstablishesTheDecision', decision.conditionGroups),{
       ...decision,
       value: parseRangeFromString(decision.value),
       conditionsThatEstablishesTheDecision:
-        decision.conditionsThatEstablishesTheDecision?.map((condition) => ({
+        decision.conditionGroups[0].conditionsThatEstablishesTheDecision?.map((condition) => (console.log('condition.value: ',condition),{
           ...condition,
           value: parseRangeFromString(condition.value),
         })),
@@ -65,11 +67,11 @@ const BusinessRulesController = ({
           ...dataDecision,
           decisionId: `Decisión ${decisions.length + 1}`,
           conditions:
-            decisionTemplate.conditionsThatEstablishesTheDecision?.map(
+            decisionTemplate.conditionGroups.conditionsThatEstablishesTheDecision?.map(
               (conditionTemplate, index) => ({
                 ...conditionTemplate,
                 value:
-                  dataDecision.conditionsThatEstablishesTheDecision?.[index]
+                  dataDecision.conditionGroups[0].conditionsThatEstablishesTheDecision?.[index]
                     ?.value ?? conditionTemplate.value,
               }),
             ) ?? [],


### PR DESCRIPTION
This PR makes the business-rules flow shape-agnostic and fixes the “first condition value not appearing” bug by normalizing conditionGroups (supports array or object via toGroupArray/getPrimaryGroup) across the form and view, merging both flat and grouped form values while preserving template order and metadata, and trimming/matching conditionName to avoid subtle mismatches; it also removes hardcoded condition metadata so fields like labelName, descriptionUse, conditionDataType, howToSetTheCondition, and i18n are dynamically sourced from the decision template. The validation was refactored from a formik closure to yup’s mixed().when(["howToSetTheDecision","decisionDataType"], …) so formik can be a const, and the submit payload mirrors the incoming conditionGroups shape (array vs object) for consistency. Lint issues are addressed by replacing ([_, v]) with elision ([, v]) and using const for formik. Changes touch BusinessRuleViewWithGroup, the form utils (useRulesFormUtilsWithGroup, extractor), and a new normalizeDecisionGroups helper, improving robustness (keeps 0/false/range objects as valid), ensuring consistent rendering in Storybook and runtime, and maintaining backward compatibility.